### PR TITLE
No more custom domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-docs.universibo.org


### PR DESCRIPTION
universibo.org has expired, documentation is not accessible anymore without this change
